### PR TITLE
add disconnect method

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -230,6 +230,10 @@ module ActiveSupport
         @data.reconnect if @data.respond_to?(:reconnect)
       end
 
+      def disconnect
+        @data.disconnect! if @data.respond_to?(:disconnect!)
+      end
+
       protected
         def write_entry(key, entry, options)
           method = options && options[:unless_exist] ? :setnx : :set


### PR DESCRIPTION
This adds a method "disconnect" to free a connection when using a free redis plan on heroku.